### PR TITLE
Rebranding

### DIFF
--- a/factory/models/mcp/tasks.go
+++ b/factory/models/mcp/tasks.go
@@ -62,8 +62,8 @@ func NewTasksModel(
 ) TasksModel {
 	return &m.TasksModel{
 		ID:                 uuid.New().String(),
-		Provider:           provider,
-		Target:             target,
+		MCPProvider:        provider,
+		TargetTask:         target,
 		LastSynced:         nil,
 		CreatedAt:          time.Now().Format("2006-01-02 15:04:05"),
 		CreatedBy:          "",

--- a/internal/models/mcp/tasks/tasks_model.go
+++ b/internal/models/mcp/tasks/tasks_model.go
@@ -55,10 +55,10 @@ type ITasksModel interface {
 	TableName() string
 	GetID() string
 	SetID(id string)
-	GetProvider() string
-	SetProvider(provider string)
-	GetTarget() string
-	SetTarget(target string)
+	GetMCPProvider() string
+	SetMCPProvider(provider string)
+	GetTargetTask() string
+	SetTargetTask(target string)
 	GetTaskType() TaskType
 	SetTaskType(taskType TaskType)
 	GetTaskExpression() string
@@ -93,8 +93,8 @@ type ITasksModel interface {
 // TasksModel represents the MCP sync tasks table
 type TasksModel struct {
 	ID                 string          `gorm:"type:uuid;primaryKey" json:"id"`
-	Provider           string          `gorm:"type:text;not null" json:"provider" example:"github"`
-	Target             string          `gorm:"type:text;not null" json:"target" example:"my-repo"`
+	MCPProvider        string          `gorm:"type:text;not null" json:"mcp_provider" example:"github"`
+	TargetTask         string          `gorm:"type:text;not null" json:"target_task" example:"my-repo"`
 	LastSynced         *time.Time      `gorm:"type:timestamp;default:now()" json:"last_synced,omitempty"`
 	CreatedAt          string          `gorm:"type:timestamp;default:now()" json:"created_at,omitempty" example:"2024-01-01T00:00:00Z"`
 	CreatedBy          string          `gorm:"type:uuid;references:users(id)" json:"created_by,omitempty"`
@@ -149,8 +149,8 @@ type CronJobIntegration struct {
 func NewTasksModel() *TasksModel {
 	return &TasksModel{
 		ID:                 "",
-		Provider:           "",
-		Target:             "",
+		MCPProvider:        "",
+		TargetTask:         "",
 		TaskType:           TaskTypeSync,
 		TaskSchedule:       JobScheduleTypeCron,
 		TaskExpression:     "2 * * * *",
@@ -178,10 +178,10 @@ func NewTasksModel() *TasksModel {
 func (t *TasksModel) TableName() string                   { return "mcp_sync_tasks" }
 func (t *TasksModel) GetID() string                       { return t.ID }
 func (t *TasksModel) SetID(id string)                     { t.ID = id }
-func (t *TasksModel) GetProvider() string                 { return t.Provider }
-func (t *TasksModel) SetProvider(provider string)         { t.Provider = provider }
-func (t *TasksModel) GetTarget() string                   { return t.Target }
-func (t *TasksModel) SetTarget(target string)             { t.Target = target }
+func (t *TasksModel) GetMCPProvider() string              { return t.MCPProvider }
+func (t *TasksModel) SetMCPProvider(provider string)      { t.MCPProvider = provider }
+func (t *TasksModel) GetTargetTask() string               { return t.TargetTask }
+func (t *TasksModel) SetTargetTask(target string)         { t.TargetTask = target }
 func (t *TasksModel) GetTaskType() TaskType               { return t.TaskType }
 func (t *TasksModel) SetTaskType(taskType TaskType)       { t.TaskType = taskType }
 func (t *TasksModel) GetTaskExpression() string           { return t.TaskExpression }
@@ -214,17 +214,17 @@ func (t *TasksModel) GetUpdatedBy() string             { return t.UpdatedBy }
 func (t *TasksModel) SetUpdatedBy(updatedBy string)    { t.UpdatedBy = updatedBy }
 
 func (t *TasksModel) Validate() error {
-	if t.Provider == "" {
-		return fmt.Errorf("provider cannot be empty")
+	if t.MCPProvider == "" {
+		return fmt.Errorf("MCP provider cannot be empty")
 	}
-	if t.Target == "" {
-		return fmt.Errorf("target cannot be empty")
+	if t.TargetTask == "" {
+		return fmt.Errorf("target task cannot be empty")
 	}
 	if t.TaskType == "" {
-		return fmt.Errorf("task_type cannot be empty")
+		return fmt.Errorf("task type cannot be empty")
 	}
 	if t.TaskExpression == "" {
-		return fmt.Errorf("task_expression cannot be empty")
+		return fmt.Errorf("task expression cannot be empty")
 	}
 	return nil
 }
@@ -268,7 +268,7 @@ func (t *TasksModel) ToCronJob() (*CronJobIntegration, error) {
 	// Build command based on task type and configuration
 	command := t.TaskCommand
 	if command == "" && t.TaskAPIEndpoint != "" {
-		command = fmt.Sprintf("MCP_TASK:%s:%s:%s", t.Provider, t.Target, string(t.TaskType))
+		command = fmt.Sprintf("MCP_TASK:%s:%s:%s", t.MCPProvider, t.TargetTask, string(t.TaskType))
 	}
 
 	return &CronJobIntegration{

--- a/internal/models/mcp/tasks/tasks_repo.go
+++ b/internal/models/mcp/tasks/tasks_repo.go
@@ -159,8 +159,8 @@ func (tr *TasksRepo) List(where ...interface{}) (xtt.TableDataHandler, error) {
 		tableHandlerMap = append(tableHandlerMap, []string{
 			fmt.Sprintf("%d", i+1),
 			task.GetID(),
-			task.GetProvider(),
-			task.GetTarget(),
+			task.GetMCPProvider(),
+			task.GetTargetTask(),
 			string(task.GetTaskType()),
 			task.GetTaskExpression(),
 			string(task.TaskStatus),

--- a/internal/models/mcp/tasks/tasks_service.go
+++ b/internal/models/mcp/tasks/tasks_service.go
@@ -45,16 +45,16 @@ func NewTasksService(repo ITasksRepo) ITasksService {
 }
 
 func (ts *TasksService) CreateTask(task ITasksModel) (ITasksModel, error) {
-	if task.GetProvider() == "" || task.GetTarget() == "" {
-		return nil, errors.New("missing required fields: provider and target are required")
+	if task.GetMCPProvider() == "" || task.GetTargetTask() == "" {
+		return nil, errors.New("missing required fields: MCP provider and target task are required")
 	}
 
 	if task.GetTaskType() == "" {
-		return nil, errors.New("missing required field: task_type is required")
+		return nil, errors.New("missing required field: task type is required")
 	}
 
 	if task.GetTaskExpression() == "" {
-		return nil, errors.New("missing required field: task_expression is required")
+		return nil, errors.New("missing required field: task expression is required")
 	}
 
 	// Validate the model


### PR DESCRIPTION
This pull request refactors the `TasksModel` and related interfaces to rename and standardize field and method names for improved clarity and alignment with the domain terminology. The most important changes include renaming `Provider` to `MCPProvider` and `Target` to `TargetTask`, updating associated methods and validation logic, and ensuring consistent usage across the codebase.

### Renaming and Standardization of Fields and Methods:
* Renamed `Provider` to `MCPProvider` and `Target` to `TargetTask` in the `TasksModel` struct and updated corresponding GORM tags and JSON field names in `internal/models/mcp/tasks/tasks_model.go`.
* Updated getter and setter methods for the renamed fields in the `ITasksModel` interface and their implementations in `TasksModel`. [[1]](diffhunk://#diff-da849802f097b20869b2e4c05eafa027b48cd8bcb28aa65da4a507f4cd4f0f9eL58-R61) [[2]](diffhunk://#diff-da849802f097b20869b2e4c05eafa027b48cd8bcb28aa65da4a507f4cd4f0f9eL181-R184)
* Updated validation logic in `Validate()` to reflect the new field names (`MCPProvider` and `TargetTask`).

### Codebase-Wide Adjustments:
* Refactored string formatting in `ToCronJob()` to use the renamed fields (`MCPProvider` and `TargetTask`) when building task commands.
* Updated the `List()` method in `TasksRepo` to display the renamed fields in table data.
* Modified `CreateTask()` in `TasksService` to validate the renamed fields and update error messages accordingly.

### Factory Initialization:
* Updated the `NewTasksModel` function in `factory/models/mcp/tasks.go` and `internal/models/mcp/tasks/tasks_model.go` to initialize the renamed fields (`MCPProvider` and `TargetTask`). [[1]](diffhunk://#diff-9092ac9cd9b02bc4ea206231a51e0aa650b7c926e2b81da68396b9c6eeef791aL65-R66) [[2]](diffhunk://#diff-da849802f097b20869b2e4c05eafa027b48cd8bcb28aa65da4a507f4cd4f0f9eL152-R153)