### PR TITLE
Rebranding

### DIFF
--- a/factory/models/mcp/preferences.go
+++ b/factory/models/mcp/preferences.go
@@ -24,7 +24,7 @@ func NewPreferencesRepo(db *gorm.DB) PreferencesRepo {
 
 func NewPreferencesModel(
 	scope string,
-	config t.JsonB,
+	config t.JSONB,
 ) PreferencesModel {
 	return &m.PreferencesModel{
 		ID:        uuid.New().String(),

--- a/factory/models/mcp/providers.go
+++ b/factory/models/mcp/providers.go
@@ -25,7 +25,7 @@ func NewProvidersRepo(db *gorm.DB) ProvidersRepo {
 func NewProvidersModel(
 	provider string,
 	orgOrGroup string,
-	config t.JsonB,
+	config t.JSONB,
 ) ProvidersModel {
 	return &m.ProvidersModel{
 		ID:         uuid.New().String(),

--- a/factory/models/mcp/tasks.go
+++ b/factory/models/mcp/tasks.go
@@ -36,8 +36,8 @@ func NewTasksModel(
 	taskCommandType string,
 	taskMethod HTTPMethod,
 	taskAPIEndpoint string,
-	taskPayload tp.JsonB,
-	taskHeaders tp.JsonB,
+	taskPayload tp.JSONB,
+	taskHeaders tp.JSONB,
 	taskRetries int,
 	taskTimeout int,
 	taskStatus TaskStatus,
@@ -47,7 +47,7 @@ func NewTasksModel(
 	taskLastRunMessage string,
 	taskCommand string,
 	taskActivated bool,
-	taskConfig tp.JsonB,
+	taskConfig tp.JSONB,
 	taskTags []string,
 	taskPriority int,
 	taskNotes string,
@@ -57,7 +57,7 @@ func NewTasksModel(
 	taskUpdatedBy string,
 	taskLastExecutedBy string,
 	taskLastExecutedAt *time.Time,
-	config tp.JsonB,
+	config tp.JSONB,
 	active bool,
 ) TasksModel {
 	return &m.TasksModel{

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/rafa-mori/gdbase
 
-go 1.24.5
+go 1.25.0
 
 require (
 	github.com/docker/docker v28.3.3+incompatible

--- a/info/manifest.json
+++ b/info/manifest.json
@@ -1,10 +1,13 @@
 {
   "name": "Kubex GDBase",
   "application": "gdbase",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "private": false,
   "published": true,
-  "aliases": ["gdbase", "kbxdb"],
+  "aliases": [
+    "gdbase",
+    "kbxdb"
+  ],
   "repository": "https://github.com/rafa-mori/gdbase",
   "homepage": "https://github.com/rafa-mori/gdbase",
   "description": "Kubex GDBase: A complete tool for managing databases, data models, and more.",
@@ -13,8 +16,17 @@
   "author": "Rafael Mori <faelmori@gmail.com>",
   "organization": "rafa-mori",
   "license": "MIT",
-  "keywords": ["gdbase", "kubex", "control", "command-line", "tool", "management"],
-  "platforms": ["linux/amd64"],
+  "keywords": [
+    "gdbase",
+    "kubex",
+    "control",
+    "command-line",
+    "tool",
+    "management"
+  ],
+  "platforms": [
+    "linux/amd64"
+  ],
   "dependencies": [
     "pkg-config",
     "tar",

--- a/internal/models/cron/cronjob_model.go
+++ b/internal/models/cron/cronjob_model.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"time"
 
-	l "github.com/rafa-mori/logz"
 	"github.com/google/uuid"
 	t "github.com/rafa-mori/gdbase/types"
+	l "github.com/rafa-mori/logz"
 
 	jobqueue "github.com/rafa-mori/gdbase/internal/models/job_queue"
 
@@ -69,10 +69,10 @@ type CronJob struct {
 	UpdatedAt      *time.Time `json:"updated_at" gorm:"default:now()" binding:"omitempty"`
 	LastExecutedAt *time.Time `json:"last_executed_at" binding:"omitempty"`
 
-	Payload t.JsonB `json:"payload" binding:"omitempty"`
-	Headers t.JsonB `json:"headers" binding:"omitempty"`
+	Payload t.JSONB `json:"payload" binding:"omitempty"`
+	Headers t.JSONB `json:"headers" binding:"omitempty"`
 
-	Metadata t.JsonB `json:"metadata" binding:"omitempty"`
+	Metadata t.JSONB `json:"metadata" binding:"omitempty"`
 }
 
 func NewCronJob(ctx context.Context, cron *CronJob, restrict bool) ICronJobModel {

--- a/internal/models/discord/discord_model.go
+++ b/internal/models/discord/discord_model.go
@@ -78,8 +78,8 @@ type IDiscordModel interface {
 	SetScopes(scopes []string)
 	GetBotPermissions() int64
 	SetBotPermissions(permissions int64)
-	GetConfig() t.JsonB
-	SetConfig(config t.JsonB)
+	GetConfig() t.JSONB
+	SetConfig(config t.JSONB)
 	GetLastActivity() time.Time
 	SetLastActivity(lastActivity time.Time)
 	GetUserID() string
@@ -119,7 +119,7 @@ type DiscordModel struct {
 	WebhookURL      string                 `gorm:"type:text" json:"webhook_url,omitempty"`
 	Scopes          []string               `gorm:"type:text[]" json:"scopes,omitempty" example:"[\"bot\", \"identify\"]"`
 	BotPermissions  int64                  `gorm:"type:bigint;default:0" json:"bot_permissions" example:"274877908992"`
-	Config          t.JsonB                `json:"config" binding:"omitempty"`
+	Config          t.JSONB                `json:"config" binding:"omitempty"`
 	LastActivity    string                 `gorm:"type:timestamp;default:now()" json:"last_activity,omitempty" example:"2024-01-01T00:00:00Z"`
 	UserID          string                 `gorm:"type:uuid;references:users(id)" json:"user_id,omitempty" example:"123e4567-e89b-12d3-a456-426614174001"`
 	TargetTaskID    string                 `gorm:"type:uuid;references:mcp_sync_tasks(id)" json:"target_task_id,omitempty" example:"123e4567-e89b-12d3-a456-426614174002"`
@@ -150,7 +150,7 @@ func NewDiscordModel() *DiscordModel {
 		WebhookURL:      "",
 		Scopes:          []string{},
 		BotPermissions:  0,
-		Config:          t.JsonB{},
+		Config:          t.JSONB{},
 		LastActivity:    time.Now().Format(time.RFC3339),
 		UserID:          "",
 		TargetTaskID:    "",
@@ -215,8 +215,8 @@ func (d *DiscordModel) GetScopes() []string                 { return d.Scopes }
 func (d *DiscordModel) SetScopes(scopes []string)           { d.Scopes = scopes }
 func (d *DiscordModel) GetBotPermissions() int64            { return d.BotPermissions }
 func (d *DiscordModel) SetBotPermissions(permissions int64) { d.BotPermissions = permissions }
-func (d *DiscordModel) GetConfig() t.JsonB                  { return d.Config }
-func (d *DiscordModel) SetConfig(config t.JsonB)            { d.Config = config }
+func (d *DiscordModel) GetConfig() t.JSONB                  { return d.Config }
+func (d *DiscordModel) SetConfig(config t.JSONB)            { d.Config = config }
 
 func (d *DiscordModel) GetLastActivity() time.Time {
 	lastActivity, _ := time.Parse(time.RFC3339, d.LastActivity)

--- a/internal/models/discord/discord_service.go
+++ b/internal/models/discord/discord_service.go
@@ -41,8 +41,8 @@ type IDiscordService interface {
 	IsTokenExpired(id string) (bool, error)
 
 	// Configuration management
-	UpdateDiscordIntegrationConfig(id string, config t.JsonB) error
-	GetDiscordIntegrationConfig(id string) (t.JsonB, error)
+	UpdateDiscordIntegrationConfig(id string, config t.JSONB) error
+	GetDiscordIntegrationConfig(id string) (t.JSONB, error)
 
 	// Upsert operations
 	UpsertDiscordIntegrationByDiscordUserID(discordUserID string, discord IDiscordModel) (IDiscordModel, error)
@@ -260,7 +260,7 @@ func (ds *DiscordService) IsTokenExpired(id string) (bool, error) {
 }
 
 // Configuration management
-func (ds *DiscordService) UpdateDiscordIntegrationConfig(id string, config t.JsonB) error {
+func (ds *DiscordService) UpdateDiscordIntegrationConfig(id string, config t.JSONB) error {
 	discord, err := ds.GetDiscordIntegrationByID(id)
 	if err != nil {
 		return err
@@ -272,7 +272,7 @@ func (ds *DiscordService) UpdateDiscordIntegrationConfig(id string, config t.Jso
 	return err
 }
 
-func (ds *DiscordService) GetDiscordIntegrationConfig(id string) (t.JsonB, error) {
+func (ds *DiscordService) GetDiscordIntegrationConfig(id string) (t.JSONB, error) {
 	discord, err := ds.GetDiscordIntegrationByID(id)
 	if err != nil {
 		return nil, err

--- a/internal/models/job_queue/job_queue.go
+++ b/internal/models/job_queue/job_queue.go
@@ -82,8 +82,8 @@ type JobQueue struct {
 	JobCommand     string    `json:"job_command" xml:"job_command" yaml:"job_command" gorm:"column:job_command"`
 	JobMethod      string    `json:"job_method" xml:"job_method" yaml:"job_method" gorm:"column:job_method"`
 	JobAPIEndpoint string    `json:"job_api_endpoint" xml:"job_api_endpoint" yaml:"job_api_endpoint" gorm:"column:job_api_endpoint"`
-	JobPayload     t.JsonB   `json:"job_payload" xml:"job_payload" yaml:"job_payload" gorm:"column:job_payload"`
-	JobHeaders     t.JsonB   `json:"job_headers" xml:"job_headers" yaml:"job_headers" gorm:"column:job_headers"`
+	JobPayload     t.JSONB   `json:"job_payload" xml:"job_payload" yaml:"job_payload" gorm:"column:job_payload"`
+	JobHeaders     t.JSONB   `json:"job_headers" xml:"job_headers" yaml:"job_headers" gorm:"column:job_headers"`
 	JobRetries     int       `json:"job_retries" xml:"job_retries" yaml:"job_retries" gorm:"column:job_retries;default:0"`
 	JobTimeout     int       `json:"job_timeout" xml:"job_timeout" yaml:"job_timeout" gorm:"column:job_timeout;default:0"`
 }
@@ -131,10 +131,10 @@ func (j *JobQueue) GetJobMethod() string                       { return j.JobMet
 func (j *JobQueue) SetJobMethod(jobMethod string)              { j.JobMethod = jobMethod }
 func (j *JobQueue) GetJobAPIEndpoint() string                  { return j.JobAPIEndpoint }
 func (j *JobQueue) SetJobAPIEndpoint(jobAPIEndpoint string)    { j.JobAPIEndpoint = jobAPIEndpoint }
-func (j *JobQueue) GetJobPayload() t.JsonB                     { return j.JobPayload }
-func (j *JobQueue) SetJobPayload(jobPayload t.JsonB)           { j.JobPayload = jobPayload }
-func (j *JobQueue) GetJobHeaders() t.JsonB                     { return j.JobHeaders }
-func (j *JobQueue) SetJobHeaders(jobHeaders t.JsonB)           { j.JobHeaders = jobHeaders }
+func (j *JobQueue) GetJobPayload() t.JSONB                     { return j.JobPayload }
+func (j *JobQueue) SetJobPayload(jobPayload t.JSONB)           { j.JobPayload = jobPayload }
+func (j *JobQueue) GetJobHeaders() t.JSONB                     { return j.JobHeaders }
+func (j *JobQueue) SetJobHeaders(jobHeaders t.JSONB)           { j.JobHeaders = jobHeaders }
 func (j *JobQueue) GetJobRetries() int                         { return j.JobRetries }
 func (j *JobQueue) SetJobRetries(jobRetries int)               { j.JobRetries = jobRetries }
 func (j *JobQueue) GetJobTimeout() int                         { return j.JobTimeout }

--- a/internal/models/mcp/preferences/preferences_model.go
+++ b/internal/models/mcp/preferences/preferences_model.go
@@ -14,8 +14,8 @@ type IPreferencesModel interface {
 	SetID(id string)
 	GetScope() string
 	SetScope(scope string)
-	GetConfig() t.JsonB
-	SetConfig(config t.JsonB)
+	GetConfig() t.JSONB
+	SetConfig(config t.JSONB)
 	GetCreatedAt() time.Time
 	SetCreatedAt(createdAt time.Time)
 	GetUpdatedAt() time.Time
@@ -31,7 +31,7 @@ type IPreferencesModel interface {
 type PreferencesModel struct {
 	ID        string  `gorm:"type:uuid;primaryKey" json:"id"`
 	Scope     string  `gorm:"type:text;not null;default:'defaults';uniqueIndex" json:"scope" example:"defaults"`
-	Config    t.JsonB `json:"config" binding:"omitempty"`
+	Config    t.JSONB `json:"config" binding:"omitempty"`
 	CreatedAt string  `gorm:"type:timestamp;default:now()" json:"created_at,omitempty" example:"2024-01-01T00:00:00Z"`
 	UpdatedAt string  `gorm:"type:timestamp;default:now()" json:"updated_at,omitempty" example:"2024-01-01T00:00:00Z"`
 	CreatedBy string  `gorm:"type:uuid;references:users(id)" json:"created_by,omitempty" example:"123e4567-e89b-12d3-a456-426614174001"`
@@ -42,7 +42,7 @@ func NewPreferencesModel() *PreferencesModel {
 	return &PreferencesModel{
 		ID:        "",
 		Scope:     "defaults",
-		Config:    t.JsonB{},
+		Config:    t.JSONB{},
 		CreatedAt: time.Now().Format(time.RFC3339),
 		UpdatedAt: time.Now().Format(time.RFC3339),
 	}
@@ -53,8 +53,8 @@ func (p *PreferencesModel) GetID() string            { return p.ID }
 func (p *PreferencesModel) SetID(id string)          { p.ID = id }
 func (p *PreferencesModel) GetScope() string         { return p.Scope }
 func (p *PreferencesModel) SetScope(scope string)    { p.Scope = scope }
-func (p *PreferencesModel) GetConfig() t.JsonB       { return p.Config }
-func (p *PreferencesModel) SetConfig(config t.JsonB) { p.Config = config }
+func (p *PreferencesModel) GetConfig() t.JSONB       { return p.Config }
+func (p *PreferencesModel) SetConfig(config t.JSONB) { p.Config = config }
 func (p *PreferencesModel) GetCreatedAt() time.Time {
 	createdAt, _ := time.Parse(time.RFC3339, p.CreatedAt)
 	return createdAt

--- a/internal/models/mcp/preferences/preferences_service.go
+++ b/internal/models/mcp/preferences/preferences_service.go
@@ -15,7 +15,7 @@ type IPreferencesService interface {
 	ListPreferences() ([]IPreferencesModel, error)
 	GetPreferencesByScope(scope string) (IPreferencesModel, error)
 	GetPreferencesByUserID(userID string) ([]IPreferencesModel, error)
-	UpsertPreferencesByScope(scope string, config t.JsonB, userID string) (IPreferencesModel, error)
+	UpsertPreferencesByScope(scope string, config t.JSONB, userID string) (IPreferencesModel, error)
 	GetContextDBService() t.IDBService
 }
 
@@ -101,7 +101,7 @@ func (ps *PreferencesService) GetPreferencesByUserID(userID string) ([]IPreferen
 	return preferences, nil
 }
 
-func (ps *PreferencesService) UpsertPreferencesByScope(scope string, config t.JsonB, userID string) (IPreferencesModel, error) {
+func (ps *PreferencesService) UpsertPreferencesByScope(scope string, config t.JSONB, userID string) (IPreferencesModel, error) {
 	// Try to find existing preferences by scope
 	existing, err := ps.repo.FindOne("scope = ?", scope)
 	if err != nil {

--- a/internal/models/mcp/providers/providers_model.go
+++ b/internal/models/mcp/providers/providers_model.go
@@ -16,8 +16,8 @@ type IProvidersModel interface {
 	SetProvider(provider string)
 	GetOrgOrGroup() string
 	SetOrgOrGroup(orgOrGroup string)
-	GetConfig() t.JsonB
-	SetConfig(config t.JsonB)
+	GetConfig() t.JSONB
+	SetConfig(config t.JSONB)
 	GetCreatedAt() time.Time
 	SetCreatedAt(createdAt time.Time)
 	GetUpdatedAt() time.Time
@@ -34,7 +34,7 @@ type ProvidersModel struct {
 	ID         string  `gorm:"type:uuid;primaryKey" json:"id"`
 	Provider   string  `gorm:"type:text;not null" json:"provider" example:"github"`
 	OrgOrGroup string  `gorm:"type:text;not null" json:"org_or_group" example:"my-org"`
-	Config     t.JsonB `json:"config" binding:"omitempty"`
+	Config     t.JSONB `json:"config" binding:"omitempty"`
 	CreatedAt  string  `gorm:"type:timestamp;default:now()" json:"created_at,omitempty" example:"2024-01-01T00:00:00Z"`
 	UpdatedAt  string  `gorm:"type:timestamp;default:now()" json:"updated_at,omitempty" example:"2024-01-01T00:00:00Z"`
 	CreatedBy  string  `gorm:"type:uuid;references:users(id)" json:"created_by,omitempty" example:"123e4567-e89b-12d3-a456-426614174001"`
@@ -46,7 +46,7 @@ func NewProvidersModel() *ProvidersModel {
 		ID:         "",
 		Provider:   "",
 		OrgOrGroup: "",
-		Config:     t.JsonB{},
+		Config:     t.JSONB{},
 		CreatedAt:  time.Now().Format(time.RFC3339),
 		UpdatedAt:  time.Now().Format(time.RFC3339),
 	}
@@ -59,8 +59,8 @@ func (p *ProvidersModel) GetProvider() string             { return p.Provider }
 func (p *ProvidersModel) SetProvider(provider string)     { p.Provider = provider }
 func (p *ProvidersModel) GetOrgOrGroup() string           { return p.OrgOrGroup }
 func (p *ProvidersModel) SetOrgOrGroup(orgOrGroup string) { p.OrgOrGroup = orgOrGroup }
-func (p *ProvidersModel) GetConfig() t.JsonB              { return p.Config }
-func (p *ProvidersModel) SetConfig(config t.JsonB)        { p.Config = config }
+func (p *ProvidersModel) GetConfig() t.JSONB              { return p.Config }
+func (p *ProvidersModel) SetConfig(config t.JSONB)        { p.Config = config }
 func (p *ProvidersModel) GetCreatedAt() time.Time {
 	createdAt, _ := time.Parse(time.RFC3339, p.CreatedAt)
 	return createdAt

--- a/internal/models/mcp/providers/providers_service.go
+++ b/internal/models/mcp/providers/providers_service.go
@@ -18,7 +18,7 @@ type IProvidersService interface {
 	GetProviderByOrgOrGroup(orgOrGroup string) ([]IProvidersModel, error)
 	GetProviderByNameAndOrg(providerName, orgOrGroup string) (IProvidersModel, error)
 	GetProvidersByUserID(userID string) ([]IProvidersModel, error)
-	UpsertProviderByNameAndOrg(providerName, orgOrGroup string, config t.JsonB, userID string) (IProvidersModel, error)
+	UpsertProviderByNameAndOrg(providerName, orgOrGroup string, config t.JSONB, userID string) (IProvidersModel, error)
 	GetContextDBService() t.IDBService
 }
 
@@ -120,7 +120,7 @@ func (ps *ProvidersService) GetProvidersByUserID(userID string) ([]IProvidersMod
 	return providers, nil
 }
 
-func (ps *ProvidersService) UpsertProviderByNameAndOrg(providerName, orgOrGroup string, config t.JsonB, userID string) (IProvidersModel, error) {
+func (ps *ProvidersService) UpsertProviderByNameAndOrg(providerName, orgOrGroup string, config t.JSONB, userID string) (IProvidersModel, error) {
 	// Try to find existing provider by name and org
 	existing, err := ps.repo.FindOne("provider = ? AND org_or_group = ?", providerName, orgOrGroup)
 	if err != nil {

--- a/internal/models/mcp/tasks/tasks_model.go
+++ b/internal/models/mcp/tasks/tasks_model.go
@@ -67,12 +67,12 @@ type ITasksModel interface {
 	SetTaskAPIEndpoint(endpoint string)
 	GetTaskMethod() HTTPMethod
 	SetTaskMethod(method HTTPMethod)
-	GetTaskPayload() tp.JsonB
-	SetTaskPayload(payload tp.JsonB)
-	GetTaskHeaders() tp.JsonB
-	SetTaskHeaders(headers tp.JsonB)
-	GetTaskConfig() tp.JsonB
-	SetTaskConfig(config tp.JsonB)
+	GetTaskPayload() tp.JSONB
+	SetTaskPayload(payload tp.JSONB)
+	GetTaskHeaders() tp.JSONB
+	SetTaskHeaders(headers tp.JSONB)
+	GetTaskConfig() tp.JSONB
+	SetTaskConfig(config tp.JSONB)
 	GetActive() bool
 	SetActive(active bool)
 	GetCreatedAt() time.Time
@@ -106,8 +106,8 @@ type TasksModel struct {
 	TaskCommandType    string          `gorm:"type:text;default:'api'" json:"task_command_type" example:"api"`
 	TaskMethod         HTTPMethod      `gorm:"type:text;default:'POST'" json:"task_method" example:"POST"`
 	TaskAPIEndpoint    string          `gorm:"type:text" json:"task_api_endpoint,omitempty" example:"/api/v1/sync"`
-	TaskPayload        tp.JsonB        `json:"task_payload" binding:"omitempty"`
-	TaskHeaders        tp.JsonB        `json:"task_headers" binding:"omitempty"`
+	TaskPayload        tp.JSONB        `json:"task_payload" binding:"omitempty"`
+	TaskHeaders        tp.JSONB        `json:"task_headers" binding:"omitempty"`
 	TaskRetries        int             `gorm:"type:integer;default:0" json:"task_retries" example:"3"`
 	TaskTimeout        int             `gorm:"type:integer;default:0" json:"task_timeout" example:"300"`
 	TaskStatus         TaskStatus      `gorm:"type:text;default:'PENDING'" json:"task_status" example:"PENDING"`
@@ -117,7 +117,7 @@ type TasksModel struct {
 	TaskLastRunMessage string          `gorm:"type:text;default:'pending'" json:"task_last_run_message" example:"Task completed successfully"`
 	TaskCommand        string          `gorm:"type:text" json:"task_command,omitempty" example:"curl -X POST ..."`
 	TaskActivated      bool            `gorm:"type:boolean;default:true" json:"task_activated" example:"true"`
-	TaskConfig         tp.JsonB        `json:"task_config" binding:"omitempty"`
+	TaskConfig         tp.JSONB        `json:"task_config" binding:"omitempty"`
 	TaskTags           []string        `gorm:"type:text[]" json:"task_tags,omitempty" example:"[\"sync\",\"github\"]"`
 	TaskPriority       int             `gorm:"type:integer;default:0" json:"task_priority" example:"1"`
 	TaskNotes          string          `gorm:"type:text" json:"task_notes,omitempty" example:"Daily sync with GitHub"`
@@ -127,7 +127,7 @@ type TasksModel struct {
 	TaskUpdatedBy      string          `gorm:"type:uuid;references:users(id)" json:"task_updated_by,omitempty"`
 	TaskLastExecutedBy string          `gorm:"type:uuid;references:users(id)" json:"task_last_executed_by,omitempty"`
 	TaskLastExecutedAt *time.Time      `gorm:"type:timestamp" json:"task_last_executed_at,omitempty"`
-	Config             tp.JsonB        `json:"config" binding:"omitempty"`
+	Config             tp.JSONB        `json:"config" binding:"omitempty"`
 	Active             bool            `gorm:"type:boolean;default:true" json:"active" example:"true"`
 }
 
@@ -161,10 +161,10 @@ func NewTasksModel() *TasksModel {
 		TaskStatus:         TaskStatusPending,
 		TaskActivated:      true,
 		TaskPriority:       0,
-		TaskPayload:        tp.JsonB{},
-		TaskHeaders:        tp.JsonB{},
-		TaskConfig:         tp.JsonB{},
-		Config:             tp.JsonB{},
+		TaskPayload:        tp.JSONB{},
+		TaskHeaders:        tp.JSONB{},
+		TaskConfig:         tp.JSONB{},
+		Config:             tp.JSONB{},
 		Active:             true,
 		CreatedAt:          time.Now().Format(time.RFC3339),
 		UpdatedAt:          time.Now().Format(time.RFC3339),
@@ -190,12 +190,12 @@ func (t *TasksModel) GetTaskAPIEndpoint() string          { return t.TaskAPIEndp
 func (t *TasksModel) SetTaskAPIEndpoint(endpoint string)  { t.TaskAPIEndpoint = endpoint }
 func (t *TasksModel) GetTaskMethod() HTTPMethod           { return t.TaskMethod }
 func (t *TasksModel) SetTaskMethod(method HTTPMethod)     { t.TaskMethod = method }
-func (t *TasksModel) GetTaskPayload() tp.JsonB            { return t.TaskPayload }
-func (t *TasksModel) SetTaskPayload(payload tp.JsonB)     { t.TaskPayload = payload }
-func (t *TasksModel) GetTaskHeaders() tp.JsonB            { return t.TaskHeaders }
-func (t *TasksModel) SetTaskHeaders(headers tp.JsonB)     { t.TaskHeaders = headers }
-func (t *TasksModel) GetTaskConfig() tp.JsonB             { return t.TaskConfig }
-func (t *TasksModel) SetTaskConfig(config tp.JsonB)       { t.TaskConfig = config }
+func (t *TasksModel) GetTaskPayload() tp.JSONB            { return t.TaskPayload }
+func (t *TasksModel) SetTaskPayload(payload tp.JSONB)     { t.TaskPayload = payload }
+func (t *TasksModel) GetTaskHeaders() tp.JSONB            { return t.TaskHeaders }
+func (t *TasksModel) SetTaskHeaders(headers tp.JSONB)     { t.TaskHeaders = headers }
+func (t *TasksModel) GetTaskConfig() tp.JSONB             { return t.TaskConfig }
+func (t *TasksModel) SetTaskConfig(config tp.JSONB)       { t.TaskConfig = config }
 func (t *TasksModel) GetActive() bool                     { return t.Active }
 func (t *TasksModel) SetActive(active bool)               { t.Active = active }
 func (t *TasksModel) GetCreatedAt() time.Time {
@@ -303,14 +303,14 @@ func (t *TasksModel) FromCronJob(cronJob *CronJobIntegration) error {
 
 	// Parse JSONB fields
 	if cronJob.Payload != "" && cronJob.Payload != "{}" {
-		var payload tp.JsonB
+		var payload tp.JSONB
 		if err := json.Unmarshal([]byte(cronJob.Payload), &payload); err == nil {
 			t.TaskPayload = payload
 		}
 	}
 
 	if cronJob.Headers != "" && cronJob.Headers != "{}" {
-		var headers tp.JsonB
+		var headers tp.JSONB
 		if err := json.Unmarshal([]byte(cronJob.Headers), &headers); err == nil {
 			t.TaskHeaders = headers
 		}

--- a/types/database.go
+++ b/types/database.go
@@ -8,26 +8,26 @@ import (
 	"os"
 	"path/filepath"
 
-	l "github.com/rafa-mori/logz"
 	glb "github.com/rafa-mori/gdbase/internal/globals"
 	ci "github.com/rafa-mori/gdbase/internal/interfaces"
 	crp "github.com/rafa-mori/gdbase/internal/security/crypto"
 	krs "github.com/rafa-mori/gdbase/internal/security/external"
 	t "github.com/rafa-mori/gdbase/internal/types"
 	gl "github.com/rafa-mori/gdbase/logger"
+	l "github.com/rafa-mori/logz"
 	"gorm.io/gorm"
 )
 
-type JsonB map[string]any
+type JSONB map[string]any
 
 // Serializer manual para o GORM
-func (m JsonB) Value() (driver.Value, error) {
+func (m JSONB) Value() (driver.Value, error) {
 	return json.Marshal(m)
 }
 
-func (m *JsonB) Scan(vl any) error {
+func (m *JSONB) Scan(vl any) error {
 	if vl == nil {
-		*m = JsonB{}
+		*m = JSONB{}
 		return nil
 	}
 	return json.Unmarshal(vl.([]byte), m)


### PR DESCRIPTION
This pull request primarily standardizes the use of the `t.JSONB` type throughout the codebase, replacing the previously used `t.JsonB`. Additionally, it includes minor updates such as bumping the Go version and updating the application manifest for clarity and consistency.

**Type Standardization:**

* Replaced all instances of `t.JsonB` with `t.JSONB` in model definitions, constructors, interfaces, and methods across the following modules: Discord, MCP Preferences, MCP Providers, Cron Jobs, Job Queue, and Tasks. This ensures consistent usage of the JSONB type throughout the codebase. [[1]](diffhunk://#diff-b6fec6e872e7c996f61df29092722cc4c506e9a93ef061c36703b7f5147a6099L81-R82) [[2]](diffhunk://#diff-b6fec6e872e7c996f61df29092722cc4c506e9a93ef061c36703b7f5147a6099L122-R122) [[3]](diffhunk://#diff-b6fec6e872e7c996f61df29092722cc4c506e9a93ef061c36703b7f5147a6099L153-R153) [[4]](diffhunk://#diff-b6fec6e872e7c996f61df29092722cc4c506e9a93ef061c36703b7f5147a6099L218-R219) [[5]](diffhunk://#diff-8caf6892ac8ec3997fd6b167c7038361bbf5953e4313334acf2604f1e4ffd2d2L44-R45) [[6]](diffhunk://#diff-8caf6892ac8ec3997fd6b167c7038361bbf5953e4313334acf2604f1e4ffd2d2L263-R263) [[7]](diffhunk://#diff-8caf6892ac8ec3997fd6b167c7038361bbf5953e4313334acf2604f1e4ffd2d2L275-R275) [[8]](diffhunk://#diff-70a3e3d7a40290813151ed5f8e8caacdf5fa1ec1d25c9823949b1f8722d5ef03L17-R18) [[9]](diffhunk://#diff-70a3e3d7a40290813151ed5f8e8caacdf5fa1ec1d25c9823949b1f8722d5ef03L34-R34) [[10]](diffhunk://#diff-70a3e3d7a40290813151ed5f8e8caacdf5fa1ec1d25c9823949b1f8722d5ef03L45-R45) [[11]](diffhunk://#diff-70a3e3d7a40290813151ed5f8e8caacdf5fa1ec1d25c9823949b1f8722d5ef03L56-R57) [[12]](diffhunk://#diff-169d6a2972d5ea2536743b49ec437184c51fbf734e4b4ed7fda6863cee6ceb93L18-R18) [[13]](diffhunk://#diff-169d6a2972d5ea2536743b49ec437184c51fbf734e4b4ed7fda6863cee6ceb93L104-R104) [[14]](diffhunk://#diff-e5a6f6fcb300a296895c3f655b21ebe4b844a02e91d715b0801bf9d68dfaa061L19-R20) [[15]](diffhunk://#diff-e5a6f6fcb300a296895c3f655b21ebe4b844a02e91d715b0801bf9d68dfaa061L37-R37) [[16]](diffhunk://#diff-e5a6f6fcb300a296895c3f655b21ebe4b844a02e91d715b0801bf9d68dfaa061L49-R49) [[17]](diffhunk://#diff-e5a6f6fcb300a296895c3f655b21ebe4b844a02e91d715b0801bf9d68dfaa061L62-R63) [[18]](diffhunk://#diff-3f4802d0b823f6597a338bb799a64a439f190e5317ec72c7210ca1f2ef203b10L21-R21) [[19]](diffhunk://#diff-e9372377625797c4c7ade1ec86f598fc586118b5106e94c792b58988d9aa6d9cL27-R27) [[20]](diffhunk://#diff-ba65e2ab41b3a9f2fe0b9218d4fd9de593516351c45e642cf98b48000bdf8a28L28-R28) [[21]](diffhunk://#diff-9092ac9cd9b02bc4ea206231a51e0aa650b7c926e2b81da68396b9c6eeef791aL39-R40) [[22]](diffhunk://#diff-9092ac9cd9b02bc4ea206231a51e0aa650b7c926e2b81da68396b9c6eeef791aL50-R50) [[23]](diffhunk://#diff-9092ac9cd9b02bc4ea206231a51e0aa650b7c926e2b81da68396b9c6eeef791aL60-R60) [[24]](diffhunk://#diff-449ebbcb8fa9d6888e698cdae442a1c0846923507222cb57e7039246b82dbab2L72-R75) [[25]](diffhunk://#diff-499ed596b6c30ae3fbae6bf67f37da5911500c4f6da9799be244cd136d95e71aL85-R86) [[26]](diffhunk://#diff-499ed596b6c30ae3fbae6bf67f37da5911500c4f6da9799be244cd136d95e71aL134-R137)

**Dependency and Manifest Updates:**

* Updated the Go version in `go.mod` from 1.24.5 to 1.25.0.
* Updated the application version to `1.2.2` and reformatted arrays for `aliases`, `keywords`, and `platforms` for better readability in `info/manifest.json`. [[1]](diffhunk://#diff-bdefd119a1674ff3e56f23cb402a9c026eb161325391fae82d289e3dbe94b28aL4-R10) [[2]](diffhunk://#diff-bdefd119a1674ff3e56f23cb402a9c026eb161325391fae82d289e3dbe94b28aL16-R29)

**Minor Code Cleanups:**

* Reordered imports in `internal/models/cron/cronjob_model.go` for improved clarity.

These changes collectively improve code consistency, maintainability, and ensure the project uses the latest dependencies and clear configuration.