### PR TITLE
feat(manifest): atualiza versão para 1.2.5

### DIFF
--- a/internal/module/info/manifest.json
+++ b/internal/module/info/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Kubex GDBase",
   "application": "gdbase",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "private": false,
   "published": true,
   "aliases": [


### PR DESCRIPTION
This pull request updates the version number of the `Kubex GDBase` module to reflect a new release.

- Version bump:
  * Updated the `version` field in `internal/module/info/manifest.json` from `1.2.4` to `1.2.5`.