### PR TITLE
fix(workflow): corrige caminhos e formatação no arquivo kubex_go_rele…

### DIFF
--- a/.github/workflows/kubex_go_release.yml
+++ b/.github/workflows/kubex_go_release.yml
@@ -3,7 +3,7 @@ name: Kubex Go Dist CI
 on:
   push:
     tags:
-      - "v*.*.*" 
+      - "v*.*.*"
   workflow_dispatch:
     inputs:
       tag_name:
@@ -38,7 +38,7 @@ env:
 
 jobs:
   # ==========================================
-  # JOB 1: Build All Platforms  
+  # JOB 1: Build All Platforms
   # ==========================================
   build:
     name: Cross-Platform Build
@@ -50,7 +50,7 @@ jobs:
       platforms: ${{ steps.manifest.outputs.platforms }}
       version-mismatch: ${{ steps.version-check.outputs.version-mismatch }}
       continue: ${{ steps.version-check.outputs.continue }}
-    
+
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
@@ -60,35 +60,33 @@ jobs:
       - name: Load Module Manifest
         id: manifest
         run: |
-          if [[ ! -f "$(git rev-parse --show-toplevel)/info/manifest.json" ]]; then
-            echo "❌ info/manifest.json not found"
+          if [[ ! -f "$(git rev-parse --show-toplevel)/internal/module/info/manifest.json" ]]; then
+            echo "❌ internal/module/info/manifest.json not found"
             exit 1
           fi
-          
-          # Extract module information
-          MODULE_NAME=$(cat $(git rev-parse --show-toplevel)/info/manifest.json | jq -r '.bin // .name // "unknown"')
-          MODULE_VERSION=$(cat $(git rev-parse --show-toplevel)/info/manifest.json | jq -r '.version // "0.0.0"')
-          PLATFORMS=$(cat $(git rev-parse --show-toplevel)/info/manifest.json | jq -r '.platforms[]?' | tr '\n' ' ' | sed 's/ $//')
 
+          # Extract module information
+          MODULE_NAME=$(cat $(git rev-parse --show-toplevel)/internal/module/info/manifest.json | jq -r '.bin // .name // "unknown"')
+          MODULE_VERSION=$(cat $(git rev-parse --show-toplevel)/internal/module/info/manifest.json | jq -r '.version // "0.0.0"')
+          PLATFORMS=$(cat $(git rev-parse --show-toplevel)/internal/module/info/manifest.json | jq -r '.platforms[]?' | tr '\n' ' ' | sed 's/ $//')
           # Validate required fields
           if [[ "$MODULE_NAME" == "unknown" || "$MODULE_NAME" == "null" ]]; then
             echo "❌ Module name not found in manifest (bin or name field required)"
             exit 1
           fi
-          
+
           if [[ -z "$PLATFORMS" ]]; then
             echo "❌ No platforms specified in manifest"
             exit 1
           fi
-          
+
           echo "module-name=$MODULE_NAME" >> $GITHUB_OUTPUT
           echo "manifest-version=$MODULE_VERSION" >> $GITHUB_OUTPUT
           echo "platforms=$PLATFORMS" >> $GITHUB_OUTPUT
-          
+
           echo "✅ Module: $MODULE_NAME"
           echo "✅ Manifest Version: $MODULE_VERSION"
           echo "✅ Platforms: $PLATFORMS"
-
       - name: Extract Version
         id: version
         run: |
@@ -97,7 +95,6 @@ jobs:
           else
             echo "version=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
           fi
-
       - name: 🔍 Validate Tag Format
         run: |
           VERSION="${{ steps.version.outputs.version }}"
@@ -107,27 +104,26 @@ jobs:
             exit 1
           fi
           echo "✅ Valid version: $VERSION"
-
       - name: Version Compatibility Check
         id: version-check
         run: |
           TAG_VERSION="${{ steps.version.outputs.version }}"
           MANIFEST_VERSION="v${{ steps.manifest.outputs.manifest-version }}"
-          
+
           # Remove 'v' prefix for comparison
           TAG_CLEAN="${TAG_VERSION#v}"
           MANIFEST_CLEAN="${MANIFEST_VERSION#v}"
-          
+
           echo "🏷️  Tag Version: $TAG_VERSION ($TAG_CLEAN)"
           echo "📋 Manifest Version: $MANIFEST_VERSION ($MANIFEST_CLEAN)"
-          
+
           if [[ "$TAG_CLEAN" != "$MANIFEST_CLEAN" ]]; then
             echo ""
             echo "❌ Version Mismatch!"
             echo "   Git Tag: $TAG_VERSION"
             echo "   Manifest: $MANIFEST_VERSION"
             echo ""
-            echo "Please update info/manifest.json version to match the git tag."
+            echo "Please update internal/module/info/manifest.json version to match the git tag."
             echo "Expected: \"version\": \"$TAG_CLEAN\""
             echo ""
             echo "🛑 Workflow will skip remaining steps for safety."
@@ -138,21 +134,19 @@ jobs:
             echo "version-mismatch=false" >> $GITHUB_OUTPUT
             echo "continue=true" >> $GITHUB_OUTPUT
           fi
-
       - name: Smart Go Setup
         id: go-setup
         if: steps.version-check.outputs.continue == 'true'
         run: |
           GO_VERSION=$(grep '^go ' $(git rev-parse --show-toplevel)/go.mod | awk '{print $2}')
-          
+
           bash -c "$(curl -sSfL 'https://raw.githubusercontent.com/rafa-mori/gosetup/main/go.sh')" -s --version "$GO_VERSION"
-          
+
           # Verify installation
           go version
-          
+
           # Output for other jobs
           echo "go-version=$GO_VERSION" >> $GITHUB_OUTPUT
-
       - name: Cache Go Modules
         if: steps.version-check.outputs.continue == 'true'
         uses: actions/cache@v4
@@ -163,22 +157,19 @@ jobs:
           key: ${{ runner.os }}-go-${{ steps.go-setup.outputs.go-version }}-${{ hashFiles('**/go.sum', '**/go.mod') }}
           restore-keys: |
             ${{ runner.os }}-go-${{ steps.go-setup.outputs.go-version }}-
-
       - name: Cross-Platform Build
         if: steps.version-check.outputs.continue == 'true'
         run: |
           MODULE_NAME="${{ steps.manifest.outputs.module-name }}"
           PLATFORMS="${{ steps.manifest.outputs.platforms }}"
-          
+
           echo "Building $MODULE_NAME for platforms: $PLATFORMS"
           ENV_PLATFORMS="${ENV_PLATFORMS:-${{ github.event.inputs.platforms }}}"
-
           if [[ -z $ENV_PLATFORMS ]]; then
             echo "No platforms specified, using default from manifest."
           else
             PLATFORMS="$ENV_PLATFORMS"
           fi
-
           for platform in $PLATFORMS; do
             # Parse platform (format: os/arch or os-arch)
             if [[ "$platform" == *"/"* ]]; then
@@ -191,25 +182,21 @@ jobs:
               echo "❌ Invalid platform format: $platform (expected: os/arch or os-arch)"
               continue
             fi
-
             # Set environment variables
             export NON_INTERACTIVE=${NON_INTERACTIVE:-${{ github.event.env.NON_INTERACTIVE }}}
             export FORCE=${FORCE:-${{ github.event.env.FORCE }}}
             export CI=${CI:-${{ github.event.env.CI }}}
             export DRY_RUN=${DRY_RUN:-${{ github.event.inputs.dry_run }}}
             export DEBUG=${DEBUG:-${{ github.event.inputs.debug }}}
-
             echo "🔨 Building for $OS/$ARCH..."
             make build "${OS:-}" "${ARCH:-}"
           done
-
       - name: Verify Build Artifacts
         if: steps.version-check.outputs.continue == 'true'
         run: |
           MODULE_NAME="${{ steps.manifest.outputs.module-name }}"
           PLATFORM_LIST="${{ steps.manifest.outputs.platforms }}"
           ARTIFACT_LIST=()
-
           for platform in $PLATFORM_LIST; do
             # Parse platform (format: os/arch or os-arch)
             if [[ "$platform" == *"/"* ]]; then
@@ -222,46 +209,37 @@ jobs:
               echo "❌ Invalid platform format: $platform (expected: os/arch or os-arch)"
               continue
             fi
-
             echo "os=${OS:-}" >> $GITHUB_OUTPUT
             echo "arch=${ARCH:-}" >> $GITHUB_OUTPUT
-            
-            if [[ ! $(basename pwd) != "bin" ]]; then
-              ls -la $(git rev-parse --show-toplevel)/bin/
-              cd $(git rev-parse --show-toplevel)/bin || exit 1
-            fi
 
+            if [[ ! $(basename pwd) != "dist" ]]; then
+              ls -la $(git rev-parse --show-toplevel)/dist/
+              cd $(git rev-parse --show-toplevel)/dist || exit 1
+            fi
             ARTIFACT_LIST+=("${MODULE_NAME:-}_${OS:-}_${ARCH:-}")
           done
-
           cd $(git rev-parse --show-toplevel)/ || exit 1
-
           echo "ARTIFACT_LIST=${ARTIFACT_LIST[*]}" >> $GITHUB_OUTPUT
           echo "ARTIFACT_COUNT=${#ARTIFACT_LIST[@]}" >> $GITHUB_OUTPUT
-          echo "ARTIFACTS_DIR=$(git rev-parse --show-toplevel)/bin" >> $GITHUB_OUTPUT
-
+          echo "ARTIFACTS_DIR=$(git rev-parse --show-toplevel)/dist" >> $GITHUB_OUTPUT
           if [[ ${#ARTIFACT_LIST[@]} -eq 0 ]]; then
             echo "❌ No build artifacts found!"
             exit 1
           else
             echo "✅ Build artifacts verified: ${ARTIFACT_LIST[*]}"
           fi
-
-          if [[ ! -f $(git rev-parse --show-toplevel)/bin/SHA256SUMS ]]; then
-            touch $(git rev-parse --show-toplevel)/bin/SHA256SUMS
+          if [[ ! -f $(git rev-parse --show-toplevel)/dist/SHA256SUMS ]]; then
+            touch $(git rev-parse --show-toplevel)/dist/SHA256SUMS
           fi
-
-          sha256sum $(git rev-parse --show-toplevel)/bin/* > $(git rev-parse --show-toplevel)/bin/SHA256SUMS
-
-          ls -la $(git rev-parse --show-toplevel)/bin/
-
+          sha256sum $(git rev-parse --show-toplevel)/dist/* > $(git rev-parse --show-toplevel)/dist/SHA256SUMS
+          ls -la $(git rev-parse --show-toplevel)/dist/
       - name: Upload Build Artifacts
         if: steps.version-check.outputs.continue == 'true'
         uses: actions/upload-artifact@v4
         with:
           name: ${{ steps.manifest.outputs.module-name }}-release-binaries
           path: |
-            bin/${{ steps.manifest.outputs.module-name }}_*
+            dist/${{ steps.manifest.outputs.module-name }}_*
           retention-days: 30
 
       - name: Version Mismatch Summary
@@ -272,13 +250,12 @@ jobs:
           echo "**Git Tag**: ${{ steps.version.outputs.version }}" >> $GITHUB_STEP_SUMMARY
           echo "**Manifest**: v${{ steps.manifest.outputs.manifest-version }}" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "Please update \`info/manifest.json\` version to match the git tag before releasing." >> $GITHUB_STEP_SUMMARY
+          echo "Please update \`internal/module/info/manifest.json\` version to match the git tag before releasing." >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "Expected change in manifest:" >> $GITHUB_STEP_SUMMARY
           echo "\`\`\`json" >> $GITHUB_STEP_SUMMARY
           echo "\"version\": \"${{ steps.version.outputs.version }}\"" >> $GITHUB_STEP_SUMMARY
           echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
-
   # ==========================================
   # JOB 2: Security Scan (Optional)
   # ==========================================
@@ -287,7 +264,7 @@ jobs:
   #   runs-on: ubuntu-latest
   #   needs: build
   #   if: github.event_name != 'workflow_dispatch' && needs.build.outputs.continue == 'true'
-    
+
   #   steps:
   #     - name: Checkout Repository
   #       uses: actions/checkout@v4
@@ -295,9 +272,9 @@ jobs:
   #     - name: Smart Go Setup
   #       run: |
   #         GO_VERSION=$(grep '^go ' $(git rev-parse --show-toplevel)/go.mod | awk '{print $2}')
-          
+
   #         bash -c "$(curl -sSfL 'https://raw.githubusercontent.com/rafa-mori/gosetup/main/go.sh')" -s --version "${GO_VERSION:-1.24.5}"
-          
+
   #         # Verify installation
   #         go version
 
@@ -328,7 +305,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     if: always() && needs.build.result == 'success' && needs.build.outputs.continue == 'true'
-    
+
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
@@ -346,7 +323,6 @@ jobs:
           MODULE_NAME="${{ needs.build.outputs.module-name }}"
           VERSION="${{ needs.build.outputs.version }}"
           PLATFORMS="${{ needs.build.outputs.platforms }}"
-
           # Convert platforms to readable format
           PLATFORM_LIST=""
           for platform in $PLATFORMS; do
@@ -360,7 +336,6 @@ jobs:
               echo "❌ Invalid platform format: $platform (expected: os/arch or os-arch)"
               continue
             fi
-
             # Add platform-specific information
             case "$platform" in
               "linux/amd64"|"linux-amd64") PLATFORM_LIST="$PLATFORM_LIST          - 🐧 **Linux (AMD64)**: \`${MODULE_NAME:-}_${OS:-}_${ARCH:-}.tar.gz\`" ;;
@@ -371,17 +346,17 @@ jobs:
               *) PLATFORM_LIST="$PLATFORM_LIST          - 📦 **${platform:-}**: \`${MODULE_NAME:-}_${OS:-}_${ARCH:-}.tar.gz\`" ;;
             esac
           done
-          
+
           cat > RELEASE_NOTES.md << EOF
           ## ${MODULE_NAME:-} Release ${VERSION:-}
-          
+
           ### What's Included
-          
+
           This release contains cross-platform binaries for:
           ${PLATFORM_LIST:-}
-          
+
           ### Installation
-          
+
           #### Linux/macOS
           \`\`\`bash
           # Download and extract
@@ -390,45 +365,44 @@ jobs:
           chmod +x ${MODULE_NAME:-}_linux_amd64
           sudo mv ${MODULE_NAME:-}_linux_amd64 /usr/local/bin/${MODULE_NAME:-}
           \`\`\`
-          
+
           #### Windows
           \`\`\`powershell
           # Download and extract the ZIP file
           # Add the executable to your PATH
           \`\`\`
-          
+
           ### Verification
-          
+
           All binaries are compressed and checksums are provided in \`SHA256SUMS\`.
-          
+
           \`\`\`bash
           # Verify checksum
           sha256sum -c SHA256SUMS
           \`\`\`
-          
+
           ### Build Information
-          
+
           - **Go Version**: ${{ needs.build.outputs.go-version }}
           - **Built on**: $(date -u '+%Y-%m-%d %H:%M:%S UTC')
           - **Commit**: ${{ github.sha }}
           - **Workflow**: ${{ github.run_id }}
-          
+
           ---
-          
+
           **Full Changelog**: [${{ github.repository }}/compare/...](https://github.com/${{ github.repository }}/compare/${{ github.event.before }}...${{ github.sha }})
           EOF
-
       - name: Create GitHub Release
         run: |
           MODULE_NAME="${{ needs.build.outputs.module-name }}"
           VERSION="${{ needs.build.outputs.version }}"
-          
+
           gh release create "${VERSION:-}" \
             ./release-assets/* \
             --title "${MODULE_NAME:-} ${VERSION:-}" \
             --notes-file RELEASE_NOTES.md \
             ${{ contains(needs.build.outputs.version, '-') && '--prerelease' || '' }}
-          
+
           echo "✅ Release created successfully!"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -437,7 +411,7 @@ jobs:
         run: |
           MODULE_NAME="${{ needs.build.outputs.module-name }}"
           PLATFORMS="${{ needs.build.outputs.platforms }}"
-          
+
           echo "## Release Created Successfully!" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "**Module**: ${MODULE_NAME:-}" >> $GITHUB_STEP_SUMMARY
@@ -445,7 +419,7 @@ jobs:
           echo "**Go Version**: ${{ needs.build.outputs.go-version }}" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "### 📦 Assets Released:" >> $GITHUB_STEP_SUMMARY
-          
+
           for platform in $PLATFORMS; do
             case "$platform" in
               "linux/amd64"|"linux-amd64") echo "- 🐧 Linux AMD64" >> $GITHUB_STEP_SUMMARY ;;


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow for Go module releases, focusing on improving the handling of module metadata and build artifacts. The main changes involve moving the manifest location, updating artifact directories from `bin` to `dist`, and ensuring all workflow steps, messages, and artifact handling are consistent with these new paths.

**Manifest and Artifact Directory Refactoring:**

* Updated all references to the module manifest from `info/manifest.json` to `internal/module/info/manifest.json`, including error messages and version mismatch instructions. [[1]](diffhunk://#diff-913fe946b3b3440e125256a3653b80a714a1b6126042f4f0a90cef41fc859bbdL63-R71) [[2]](diffhunk://#diff-913fe946b3b3440e125256a3653b80a714a1b6126042f4f0a90cef41fc859bbdL130-R126) [[3]](diffhunk://#diff-913fe946b3b3440e125256a3653b80a714a1b6126042f4f0a90cef41fc859bbdL275-L281)
* Changed all build artifact directory references from `bin` to `dist`, including artifact verification, SHA256SUMS handling, and upload paths.

**General Workflow Cleanup:**

* Removed unnecessary blank lines and improved formatting for better readability and maintainability throughout the workflow steps. [[1]](diffhunk://#diff-913fe946b3b3440e125256a3653b80a714a1b6126042f4f0a90cef41fc859bbdL91) [[2]](diffhunk://#diff-913fe946b3b3440e125256a3653b80a714a1b6126042f4f0a90cef41fc859bbdL100) [[3]](diffhunk://#diff-913fe946b3b3440e125256a3653b80a714a1b6126042f4f0a90cef41fc859bbdL110) [[4]](diffhunk://#diff-913fe946b3b3440e125256a3653b80a714a1b6126042f4f0a90cef41fc859bbdL141) [[5]](diffhunk://#diff-913fe946b3b3440e125256a3653b80a714a1b6126042f4f0a90cef41fc859bbdL155) [[6]](diffhunk://#diff-913fe946b3b3440e125256a3653b80a714a1b6126042f4f0a90cef41fc859bbdL166) [[7]](diffhunk://#diff-913fe946b3b3440e125256a3653b80a714a1b6126042f4f0a90cef41fc859bbdL175-L181) [[8]](diffhunk://#diff-913fe946b3b3440e125256a3653b80a714a1b6126042f4f0a90cef41fc859bbdL194-L212) [[9]](diffhunk://#diff-913fe946b3b3440e125256a3653b80a714a1b6126042f4f0a90cef41fc859bbdL349) [[10]](diffhunk://#diff-913fe946b3b3440e125256a3653b80a714a1b6126042f4f0a90cef41fc859bbdL363) [[11]](diffhunk://#diff-913fe946b3b3440e125256a3653b80a714a1b6126042f4f0a90cef41fc859bbdL420)