### PR TITLE
Feat/planning seed

### DIFF
--- a/internal/module/info/manifest.json
+++ b/internal/module/info/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Kubex GDBase",
   "application": "gdbase",
-  "version": "1.2.9",
+  "version": "1.2.10",
   "private": false,
   "published": true,
   "aliases": [

--- a/internal/services/rabbitmq.go
+++ b/internal/services/rabbitmq.go
@@ -68,8 +68,8 @@ func SetupRabbitMQ(config *t.RabbitMQ, dockerService IDockerService) error {
 
 	portBindings := []nat.PortMap{
 		{
-			"5672/tcp":  []nat.PortBinding{{HostIP: "127.0.0.1", HostPort: "5672"}},  // publica AMQP
-			"15672/tcp": []nat.PortBinding{{HostIP: "127.0.0.1", HostPort: "15672"}}, // publica console
+			nat.Port(fmt.Sprintf("%s/tcp", config.Port)):           []nat.PortBinding{{HostIP: "127.0.0.1", HostPort: fmt.Sprintf("%v", config.Port)}},           // publica AMQP
+			nat.Port(fmt.Sprintf("%s/tcp", config.ManagementPort)): []nat.PortBinding{{HostIP: "127.0.0.1", HostPort: fmt.Sprintf("%v", config.ManagementPort)}}, // publica console
 		},
 	}
 

--- a/internal/services/utils.go
+++ b/internal/services/utils.go
@@ -251,7 +251,7 @@ func SetupDatabaseServices(d IDockerService, config *t.DBConfig) error {
 					rabbitUser = "gobe"
 				}
 				if rabbitCfg.Password == "" {
-					rabbitPassKey, rabbitPassErr := glb.GetOrGenPasswordKeyringPass("rabbitmq")
+					rabbitPassKey, rabbitPassErr := glb.GetOrGenPasswordKeyringPass(rabbitCfg.Reference.Name)
 					if rabbitPassErr != nil {
 						gl.Log("error", "Skipping RabbitMQ setup due to error generating password")
 						gl.Log("debug", fmt.Sprintf("Error generating key: %v", rabbitPassErr))
@@ -314,8 +314,8 @@ func SetupDatabaseServices(d IDockerService, config *t.DBConfig) error {
 				}
 				portBindings := []nat.PortMap{
 					{
-						"5672/tcp":  []nat.PortBinding{{HostIP: "127.0.0.1", HostPort: "5672"}},  // publica AMQP
-						"15672/tcp": []nat.PortBinding{{HostIP: "127.0.0.1", HostPort: "15672"}}, // publica console
+						nat.Port(fmt.Sprintf("%s/tcp", rabbitCfg.Port)):           []nat.PortBinding{{HostIP: "127.0.0.1", HostPort: fmt.Sprintf("%v", rabbitCfg.Port)}},           // publica AMQP
+						nat.Port(fmt.Sprintf("%s/tcp", rabbitCfg.ManagementPort)): []nat.PortBinding{{HostIP: "127.0.0.1", HostPort: fmt.Sprintf("%v", rabbitCfg.ManagementPort)}}, // publica console
 					},
 				}
 
@@ -329,7 +329,7 @@ func SetupDatabaseServices(d IDockerService, config *t.DBConfig) error {
 					[]string{
 						"RABBITMQ_DEFAULT_USER=" + rabbitUser,
 						"RABBITMQ_DEFAULT_PASS=" + rabbitPass,
-						"RABBITMQ_DEFAULT_VHOST=" + rabbitCfg.Vhost, // Se adicionar o campo Vhost
+						"RABBITMQ_DEFAULT_VHOST=" + rabbitCfg.Vhost,
 						"RABBITMQ_PORT=" + rabbitCfg.Port.(string),
 						"RABBITMQ_DB_NAME=" + rabbitCfg.Reference.Name,
 						"RABBITMQ_DB_VOLUME=" + rabbitCfg.Volume,

--- a/types/database.go
+++ b/types/database.go
@@ -174,11 +174,11 @@ func newDBConfig(name, filePath string, enabled bool, logger l.Logger, debug boo
 				gl.Log("error", fmt.Sprintf("Error getting password from keyring: %v", redisPassErr))
 				return nil
 			}
-			// rabbitPass, rabbitPassErr := getPasswordFromKeyring(name + "_RabbitMQ")
-			// if rabbitPassErr != nil {
-			// 	gl.Log("error", fmt.Sprintf("Error getting password from keyring: %v", rabbitPassErr))
-			// 	return nil
-			// }
+			rabbitPass, rabbitPassErr := getPasswordFromKeyring(name + "_RabbitMQ")
+			if rabbitPassErr != nil {
+				gl.Log("error", fmt.Sprintf("Error getting password from keyring: %v", rabbitPassErr))
+				return nil
+			}
 
 			dbConfigDefault := &DBConfig{
 				Databases: map[string]*Database{
@@ -214,7 +214,7 @@ func newDBConfig(name, filePath string, enabled bool, logger l.Logger, debug boo
 						FilePath:       filePath,
 						Enabled:        true,
 						Username:       "gobe",
-						Password:       "s3cret",
+						Password:       rabbitPass,
 						Port:           "5672",
 						ManagementPort: "15672",
 						Vhost:          "gobe",


### PR DESCRIPTION
This pull request updates the RabbitMQ service configuration to make port and password management more flexible and secure. The main changes involve dynamically configuring RabbitMQ ports based on user input, improving password handling by using keyring-based retrieval, and removing hardcoded values.

Configuration and Port Management Improvements:
* The RabbitMQ AMQP and management ports are now dynamically assigned using values from the configuration (`config.Port` and `config.ManagementPort`) instead of being hardcoded to `5672` and `15672`. This affects both `internal/services/rabbitmq.go` and `internal/services/utils.go`. [[1]](diffhunk://#diff-593221ede0c648692660e5463e1ef97d5106ffebfd0a47b7f02775374a534c59L71-R72) [[2]](diffhunk://#diff-5f84ba307bf664282003a6a8d6dbb427b477a3c01e5ab1a8fc71969e6f81d14dL317-R318)
* The environment variable setup for RabbitMQ in Docker now uses the configured port values, ensuring consistency with the dynamic port assignment.

Security and Password Handling:
* Passwords for RabbitMQ are now retrieved from the keyring using the specific RabbitMQ reference name, improving security and supporting multiple instances.
* The code for retrieving the RabbitMQ password from the keyring is now active (was previously commented out), and the password is injected into the configuration instead of a hardcoded value. [[1]](diffhunk://#diff-8abaf6af6a28ddbfa805539638e678882c5fd44ea976c69ef73553315a60c15cL177-R181) [[2]](diffhunk://#diff-8abaf6af6a28ddbfa805539638e678882c5fd44ea976c69ef73553315a60c15cL217-R217)

Other:
* The application version in `internal/module/info/manifest.json` has been incremented from `1.2.9` to `1.2.10`.