### PR TITLE
Feat/planning seed

### DIFF
--- a/internal/models/dsts.go
+++ b/internal/models/dsts.go
@@ -1,3 +1,4 @@
+// Package models implements the base structures and functions for managing data models in the application.
 package models
 
 import (

--- a/internal/services/docker_service.go
+++ b/internal/services/docker_service.go
@@ -358,7 +358,7 @@ func (d *DockerService) GetVolumesList() ([]*v.Volume, error) {
 
 	var volumeList []*v.Volume
 	for _, volume := range volumes.Volumes {
-		if volume.Name == "gdbase-pg-data" || volume.Name == "gdbase-redis-data" {
+		if volume.Name == "gdbase-pg-data" /* || volume.Name != "gdbase-redis-data" */ {
 			volumeList = append(volumeList, volume)
 		}
 	}

--- a/internal/services/utils.go
+++ b/internal/services/utils.go
@@ -196,81 +196,6 @@ func SetupDatabaseServices(d IDockerService, config *t.DBConfig) error {
 								gl.Log("error", fmt.Sprintf("❌ Erro ao criar volume do PostgreSQL: %v", err))
 								continue
 							}
-
-							// // Check if Password is empty, if so, try to retrieve it from keyring
-							// // if not found, generate a new one
-							// if dbConfig.Password == "" {
-							// 	pgPassKey, pgPassErr := glb.GetOrGenPasswordKeyringPass("pgpass")
-							// 	if pgPassErr != nil {
-							// 		gl.Log("error", fmt.Sprintf("Error generating key: %v", pgPassErr))
-							// 		continue
-							// 	}
-							// 	dbConfig.Password = string(pgPassKey)
-							// } else {
-							// 	gl.Log("debug", fmt.Sprintf("Password found in config: %s", dbConfig.Password))
-							// }
-							// if dbConfig.Volume == "" {
-							// 	dbConfig.Volume = os.ExpandEnv(glb.DefaultPostgresVolume)
-							// }
-							// pgVolRootDir := os.ExpandEnv(dbConfig.Volume)
-							// pgVolInitDir := filepath.Join(pgVolRootDir, "init")
-							// if err := os.MkdirAll(pgVolInitDir, 0755); err != nil {
-							// 	gl.Log("error", fmt.Sprintf("❌ Erro ao criar diretório do PostgreSQL: %v", err))
-							// 	continue
-							// }
-							// gl.Log("info", fmt.Sprintf("PostgreSQL init directory: %s", pgVolInitDir))
-
-							// // Write the init script to the init directory
-							// // Check if the init script already exists
-							// initScriptPath := filepath.Join(pgVolInitDir, "001_init.sql")
-							// if _, err := os.Stat(initScriptPath); err == nil {
-							// 	gl.Log("debug", fmt.Sprintf("Init script %s already exists, skipping creation", initScriptPath))
-							// } else {
-							// 	// userGroupArg := []string{}
-							// 	// user, err := u.GetPrimaryUser()
-							// 	// if err == nil {
-							// 	// 	group, err := u.GetPrimaryGroup()
-							// 	// 	if err != nil {
-							// 	// 		gl.Log("error", fmt.Sprintf("❌ Erro ao obter grupo primário: %v", err))
-							// 	// 		continue
-							// 	// 	}
-							// 	// 	userGroupArg = []string{user, group}
-							// 	// }
-							// 	// if err := u.EnsureFile(initScriptPath, 0644, userGroupArg); err != nil {
-							// 	// 	gl.Log("error", fmt.Sprintf("❌ Erro ao criar diretório do PostgreSQL: %v", err))
-							// 	// 	continue
-							// 	// }
-							// 	if err := os.WriteFile(initScriptPath, initDBSQL, 0644); err != nil {
-							// 		gl.Log("error", fmt.Sprintf("❌ Erro ao criar diretório do PostgreSQL: %v", err))
-							// 		continue
-							// 	}
-							// 	gl.Log("info", fmt.Sprintf("Init script written to %s", initScriptPath))
-							// }
-
-							// // Create the volume for PostgreSQL, if exists definitions on the config
-							// if err := d.CreateVolume("gdbase-pg-init", pgVolInitDir); err != nil {
-							// 	gl.Log("error", fmt.Sprintf("❌ Erro ao criar volume do PostgreSQL: %v", err))
-							// 	continue
-							// }
-							// pgVolDataDir := filepath.Join(pgVolRootDir, "pgdata")
-							// if _, err := os.Stat(pgVolDataDir); os.IsNotExist(err) {
-							// 	// if err := u.EnsureDir(pgVolDataDir, 0755, []string{}); err != nil {
-							// 	// 	gl.Log("error", fmt.Sprintf("❌ Erro ao criar diretório do PostgreSQL: %v", err))
-							// 	// 	continue
-							// 	// }
-							// 	if err := os.MkdirAll(pgVolDataDir, 0755); err != nil {
-							// 		gl.Log("error", fmt.Sprintf("❌ Erro ao criar diretório do PostgreSQL: %v", err))
-							// 		continue
-							// 	}
-							// 	if _, err := os.Stat(pgVolDataDir); os.IsNotExist(err) {
-							// 		gl.Log("error", fmt.Sprintf("❌ Erro ao criar diretório do PostgreSQL: %v", err))
-							// 		continue
-							// 	}
-							// }
-							// if err := d.CreateVolume("gdbase-pg-data", pgVolDataDir); err != nil {
-							// 	gl.Log("error", fmt.Sprintf("❌ Erro ao criar volume do PostgreSQL: %v", err))
-							// 	continue
-							// }
 							// Check if the port is already in use and find an available one if necessary
 							if dbConfig.Port == nil || dbConfig.Port == "" {
 								dbConfig.Port = "5432"
@@ -348,9 +273,9 @@ func SetupDatabaseServices(d IDockerService, config *t.DBConfig) error {
 				if rabbitCfg.Reference.Name == "" {
 					rabbitCfg.Reference.Name = "gdbase-rabbitmq"
 				}
-				if rabbitCfg.Volume == "" {
-					rabbitCfg.Volume = os.ExpandEnv(glb.DefaultRabbitMQVolume)
-				}
+				// if rabbitCfg.Volume == "" {
+				// 	rabbitCfg.Volume = os.ExpandEnv(glb.DefaultRabbitMQVolume)
+				// }
 				if rabbitCfg.Host == "" {
 					rabbitCfg.Host = "localhost"
 				}
@@ -416,16 +341,16 @@ func SetupDatabaseServices(d IDockerService, config *t.DBConfig) error {
 						"RABBITMQ_DEFAULT_VHOST=" + rabbitCfg.Vhost,
 						"RABBITMQ_PORT=" + rabbitCfg.Port.(string),
 						"RABBITMQ_DB_NAME=" + rabbitCfg.Reference.Name,
-						"RABBITMQ_DB_VOLUME=" + rabbitCfg.Volume,
+						// "RABBITMQ_DB_VOLUME=" + rabbitCfg.Volume,
 						"RABBITMQ_ERLANG_COOKIE=" + rabbitCfg.ErlangCookie,
 						"RABBITMQ_PORT_5672_TCP_ADDR=" + rabbitCfg.Host,
 						"RABBITMQ_PORT_5672_TCP_PORT=" + rabbitCfg.Port.(string),
 						"RABBITMQ_PORT_15672_TCP_ADDR=" + rabbitCfg.Host,
 						"RABBITMQ_PORT_15672_TCP_PORT=" + rabbitCfg.Port.(string),
 					}, portBindings,
-					map[string]struct{}{
+					map[string]struct{}{}, /* map[string]struct{}{
 						fmt.Sprintf("%s:/var/lib/rabbitmq", rabbitCfg.Volume): {},
-					},
+					}, */
 				)
 				services = append(services, dbConnObj)
 			}
@@ -501,7 +426,7 @@ func SetupDatabaseServices(d IDockerService, config *t.DBConfig) error {
 		// 	gl.Log("info", fmt.Sprintf("✅ %s já está rodando!", srv.Name))
 		// 	continue
 		// }
-		if err := d.StartContainer(srv.Name, srv.Image, srv.Env, mapPorts, srv.Volumes); err != nil {
+		if err := d.StartContainer(srv.Name, srv.Image, srv.Env, mapPorts, nil); err != nil {
 			return err
 		}
 	}

--- a/internal/services/utils.go
+++ b/internal/services/utils.go
@@ -77,10 +77,10 @@ func FindAvailablePort(basePort int, maxAttempts int) (string, error) {
 			return "", fmt.Errorf("error checking port %s: %w", port, err)
 		}
 		if !isOpen {
-			fmt.Printf("⚠️ Port %s is occupied, trying the next one...\n", port)
+			gl.Log("warn", fmt.Sprintf("⚠️ Port %s is occupied, trying the next one...\n", port))
 			continue
 		}
-		fmt.Printf("✅ Available port found: %s\n", port)
+		gl.Log("info", fmt.Sprintf("✅ Available port found: %s\n", port))
 		return port, nil
 	}
 	return "", fmt.Errorf("no available port in range %d-%d", basePort, basePort+maxAttempts-1)
@@ -89,7 +89,7 @@ func IsServiceRunning(serviceName string) bool {
 	cmd := exec.Command("docker", "ps", "--filter", fmt.Sprintf("name=%s", serviceName), "--format", "{{.Names}}")
 	output, err := cmd.Output()
 	if err != nil {
-		fmt.Printf("❌ Error checking containers: %v\n", err)
+		gl.Log("error", fmt.Sprintf("❌ Error checking containers: %v\n", err))
 	}
 	return string(output) != ""
 }
@@ -125,7 +125,7 @@ func WriteInitDBSQL(initVolumePath, initDBSQL, initDBSQLData string) (string, er
 		gl.Log("error", fmt.Sprintf("Error writing file: %v", err))
 		return "", err
 	}
-	fmt.Printf("✅ File %s created successfully!\n", filePath)
+	gl.Log("info", fmt.Sprintf("✅ File %s created successfully!\n", filePath))
 	return filePath, nil
 }
 func SetupDatabaseServices(d IDockerService, config *t.DBConfig) error {
@@ -326,7 +326,7 @@ func SetupDatabaseServices(d IDockerService, config *t.DBConfig) error {
 		if config.Messagery.RabbitMQ != nil && config.Messagery.RabbitMQ.Enabled {
 			// Check if the RabbitMQ service is already running
 			if IsServiceRunning("gdbase-rabbitmq") {
-				fmt.Printf("✅ %s já está rodando!\n", "gdbase-rabbitmq")
+				gl.Log("info", fmt.Sprintf("✅ %s já está rodando!\n", "gdbase-rabbitmq"))
 			} else {
 				rabbitCfg := config.Messagery.RabbitMQ
 				rabbitUser := rabbitCfg.Username
@@ -433,10 +433,10 @@ func SetupDatabaseServices(d IDockerService, config *t.DBConfig) error {
 	postRabbit:
 		if config.Messagery.Redis != nil && config.Messagery.Redis.Enabled {
 			if IsServiceRunning("gdbase-redis") {
-				fmt.Printf("✅ %s já está rodando!\n", "gdbase-redis")
+				gl.Log("info", fmt.Sprintf("✅ %s já está rodando!\n", "gdbase-redis"))
 			} else {
 				if err := d.StartContainerByName("gdbase-redis"); err == nil {
-					fmt.Printf("✅ %s já está rodando!\n", "gdbase-redis")
+					gl.Log("info", fmt.Sprintf("✅ %s já está rodando!\n", "gdbase-redis"))
 				} else {
 					rdsCfg := config.Messagery.Redis
 					redisPass := rdsCfg.Password
@@ -589,7 +589,7 @@ func AskToStartDocker() bool {
 	case response := <-responseCh:
 		return response == "Y"
 	case <-time.After(15 * time.Second):
-		fmt.Println("\nTempo esgotado. Docker não será ativado.")
+		gl.Log("warn", "\nTempo esgotado. Docker não será ativado.")
 		return false
 	}
 }


### PR DESCRIPTION
This pull request primarily refactors logging throughout the `internal/services/utils.go` file, replacing direct `fmt.Printf` and `fmt.Println` calls with the structured `gl.Log` function. It also comments out or removes several sections related to volume management and environment variable configuration for database services, particularly for RabbitMQ and Redis. These changes aim to standardize logging and simplify service setup logic.

**Logging improvements:**

* Replaced all `fmt.Printf` and `fmt.Println` statements with `gl.Log` for consistent logging across service utility functions, including port availability, service status checks, file creation, and Docker activation timeout messages. [[1]](diffhunk://#diff-5f84ba307bf664282003a6a8d6dbb427b477a3c01e5ab1a8fc71969e6f81d14dL80-R83) [[2]](diffhunk://#diff-5f84ba307bf664282003a6a8d6dbb427b477a3c01e5ab1a8fc71969e6f81d14dL92-R92) [[3]](diffhunk://#diff-5f84ba307bf664282003a6a8d6dbb427b477a3c01e5ab1a8fc71969e6f81d14dL128-R128) [[4]](diffhunk://#diff-5f84ba307bf664282003a6a8d6dbb427b477a3c01e5ab1a8fc71969e6f81d14dL329-R254) [[5]](diffhunk://#diff-5f84ba307bf664282003a6a8d6dbb427b477a3c01e5ab1a8fc71969e6f81d14dL592-R517)

**Service and volume management simplification:**

* Commented out or removed logic for setting up RabbitMQ and Redis volumes, including environment variable assignments and volume bindings when starting containers. This affects how volumes are handled for these services during setup. [[1]](diffhunk://#diff-5f84ba307bf664282003a6a8d6dbb427b477a3c01e5ab1a8fc71969e6f81d14dL351-R278) [[2]](diffhunk://#diff-5f84ba307bf664282003a6a8d6dbb427b477a3c01e5ab1a8fc71969e6f81d14dL419-R364) [[3]](diffhunk://#diff-5f84ba307bf664282003a6a8d6dbb427b477a3c01e5ab1a8fc71969e6f81d14dL504-R429)
* Removed or commented out legacy code for PostgreSQL volume and initialization script setup, streamlining the database service configuration process.

**Other changes:**

* Modified the volume filtering logic in `GetVolumesList` to only include the `gdbase-pg-data` volume, commenting out the check for `gdbase-redis-data`.
* Added a package documentation comment to `internal/models/dsts.go` for improved codebase clarity.