### PR TITLE
Atualiza a versão para 1.2.13 e remove plataformas não suportadas do …

### DIFF
--- a/internal/module/info/manifest.json
+++ b/internal/module/info/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Kubex GDBase",
   "application": "gdbase",
-  "version": "1.2.12",
+  "version": "1.2.13",
   "private": false,
   "published": true,
   "aliases": [
@@ -24,10 +24,7 @@
     "management"
   ],
   "platforms": [
-    "linux/amd64",
-    "linux/arm64",
-    "darwin/amd64",
-    "darwin/arm64"
+    "linux/amd64"
   ],
   "dependencies": [
     "pkg-config",


### PR DESCRIPTION
This pull request updates the `internal/module/info/manifest.json` file with minor version and platform support changes. The most notable update is the restriction of supported platforms to only `linux/amd64`.

Version and platform updates:

* Incremented the module version from `1.2.12` to `1.2.13` to reflect the new release.
* Limited the supported platforms to only `linux/amd64`, removing support for `linux/arm64`, `darwin/amd64`, and `darwin/arm64`.